### PR TITLE
WIP: prepare for documentation stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ PipelineNode{
   gcpDockerRegistryPrefix = "eu.gcr.io"
   sshCredentialsId = "jenkins-ssh-key"
 
+  documentation = [:]
+
   branchEnvs = [
     master: [
       friendlyEnvName: "production",

--- a/vars/PipelineNode.groovy
+++ b/vars/PipelineNode.groovy
@@ -93,6 +93,20 @@ def call(body) {
       }
       // end of Test stage
 
+      // start of Documentation stage
+      stage('Documentation') {
+        if(config.documentation) {
+          createNodeComposeDocsEnv(config, './documentation.json')
+          sh(script: "docker-compose -f documentation.json up --no-start")
+          sh(script: "docker-compose -f documentation.json run main npm run docs")
+          sh(script: "docker-compose -f documentation.json rm -s -f")
+          archiveArtifacts(artifacts: './docs-output/index.html')
+        } else {
+          echo("skipping documentation.")
+        }
+      }
+      // end of Documentation stage
+
       // start of Deploy stage
       stage('Deploy') {
         pipelineStep = "deploy"

--- a/vars/createNodeComposeDocsEnv.groovy
+++ b/vars/createNodeComposeDocsEnv.groovy
@@ -1,0 +1,25 @@
+import groovy.json.*
+
+def call(Map config, String filename) {
+
+  template = [
+    version: '3.1',
+    services: [
+      main: [
+        image: config.dockerImageTag,
+        build: [
+          context: './repo'
+        ],
+        volumes: [
+          "./docs-output:/usr/src/app/docs-output"
+        ]
+      ]
+    ]
+  ]
+
+  sh(script: 'rm -rf ./docs-output')
+  sh(script: 'mkdir -p ./docs-output')
+
+  def manifest = JsonOutput.toJson(template)
+  writeFile(file: filename, text: manifest)
+}

--- a/vars/processNodeConfig.groovy
+++ b/vars/processNodeConfig.groovy
@@ -28,6 +28,7 @@ def call(Map cfg, String branch, String build){
   config.helmValues = getNodeHelmValues(config.envDetails)
   config.helmChart = getNodeHelmChart(config.envDetails)
   config.testConfig = cfg.testConfig
+  config.documentation = cfg.documentation
 
   // apply some sanity checks
   validateEnvDetailsString('k8sNamespace', config)


### PR DESCRIPTION
Adding optional step which triggers `npm run docs`, output must be forwarded to `./docs-output` in the Nodejs project. 