### PR TITLE
Upload docs to gcs

### DIFF
--- a/vars/PipelineNode.groovy
+++ b/vars/PipelineNode.groovy
@@ -100,7 +100,8 @@ def call(body) {
           sh(script: "docker-compose -f documentation.json up --no-start")
           sh(script: "docker-compose -f documentation.json run main npm run docs")
           sh(script: "docker-compose -f documentation.json rm -s -f")
-          archiveArtifacts(artifacts: 'docs-output/index.html')
+          createNodeDocumentationGcsBucket(config)
+          uploadNodeDocumentation(config)
         } else {
           echo("skipping documentation.")
         }

--- a/vars/createNodeDocumentationGcsBucket.groovy
+++ b/vars/createNodeDocumentationGcsBucket.groovy
@@ -1,0 +1,5 @@
+def call(Map config) {
+  def storageClass = config.documenation.storageClass ? storageClassconfig.documenation.storageClass : "regional"
+  def location = config.documenation.location ? config.documenation.location : "europe-west3"
+  sh(script: "gsutil mb -c ${storageClass} -l ${location} ${config.documentation.bucketUrl}")
+}

--- a/vars/processNodeConfig.groovy
+++ b/vars/processNodeConfig.groovy
@@ -42,8 +42,12 @@ def call(Map cfg, String branch, String build){
   if(config.secretsInjection) { validateSecretsInjection(config.secretsInjection) }
   echo("Validating secretsInjection for the test env.")
   if(config.testConfig) { validateSecretsInjection(config.testConfig.secretsInjection) }
-  // test env secrets injection
 
+  // check documenation values
+  if(config.documenation) {
+    if(!config.documenation.bucketUrl) { error(message: "documentation/buckerUrl must be set.") }
+    if(!config.documenation.gcpProjectId) { error(message: "documentation/gcpProjectId must be set.") }
+  }
 
   // prepare Helm release name here
   config.helmReleaseName = "${config.projectFriendlyName}-" +

--- a/vars/uploadNodeDocumentation.groovy
+++ b/vars/uploadNodeDocumentation.groovy
@@ -1,0 +1,15 @@
+def call(Map config) {
+
+  def pathPrefix
+  if(config.documentation.pathPrefix) {
+    pathPrefix = config.documentation.pathPrefix
+  } else {
+    pathPrefix = "${config.projectFriendlyName}-${config.appName}"
+  }
+
+  def command = "gsutil cp ./docs-output/index.html " +
+    "${config.documentation.bucketUrl}/" +
+    "${pathPrefix}/index.html"
+
+  sh(script: command)
+}


### PR DESCRIPTION
This feature upload generated docs (`npm run docs`) to the GCS bucket if `documentation` variable specified.