### PR TITLE
Fix desired fail on NPM audit

### DIFF
--- a/vars/PipelineNode.groovy
+++ b/vars/PipelineNode.groovy
@@ -99,7 +99,7 @@ def call(body) {
         if(config.envDetails.runNpmAudit) {
           createNodeComposeNpmAuditEnv(config, './npm-audit.json')
           sh(script: "docker-compose -f npm-audit.json up --no-start")
-          sh(script: "docker-compose -f npm-audit.json run main npm audit --production --audit-level=high | tee ci-outputs/npm-audit/audit.json")
+          sh(script: "docker-compose -f npm-audit.json run main npm audit --production --audit-level=high")
         } else {
           echo "NPM Audit stage has been skipped based on the Jenkinsfile configuration"
         }


### PR DESCRIPTION
🐛 Do not write NPM audit to file that we do not read anywhere, instead just print out (and honor exit code)