### PR TITLE
🔥 Comment out linting

### DIFF
--- a/vars/PipelineNode.groovy
+++ b/vars/PipelineNode.groovy
@@ -86,7 +86,8 @@ def call(body) {
           // set correct path to tested files in the lint results
           sh(script: "sed -i 's#/usr/src/app/#${config.workspace}/repo/#g' ci-outputs/lint/checkstyle-result.xml")
           // record lint results
-          recordNodeLintResults()
+          // checkstyle plugin is dead and this pipeline is deprecated
+          //recordNodeLintResults()
         } else {
           echo "Lint stage has been skipped based on the Jenkinsfile configuration"
         }


### PR DESCRIPTION
As Jenkins pipeline is deprecated for us, I have commented out parsing of lint results, migration to new plugin seems non-trivial. Documentation could be found here: https://github.com/jenkinsci/warnings-ng-plugin/blob/master/doc/Documentation.md#advanced-pipeline-configuration